### PR TITLE
➕ Add `bcr.0` packages

### DIFF
--- a/modules/ll_asio/1.24.0-bcr.0/MODULE.bazel
+++ b/modules/ll_asio/1.24.0-bcr.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "ll_asio",
+    version = "1.24.0-bcr.0",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_ll", version = "20230216.0")

--- a/modules/ll_asio/1.24.0-bcr.0/patches/asio_bzlmod_compatibility_patch.diff
+++ b/modules/ll_asio/1.24.0-bcr.0/patches/asio_bzlmod_compatibility_patch.diff
@@ -1,0 +1,38 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 00000000..cd3fa5f4
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,12 @@
++load("@rules_ll//ll:defs.bzl", "ll_library")
++
++ll_library(
++    name = "asio",
++    defines = [
++        "ASIO_STANDALONE",
++        "ASIO_NO_DEPRECATED",
++    ],
++    exposed_hdrs = glob(["asio/include/**/*.h*"] + ["asio/include/**/*.i*"]),
++    exposed_includes = ["asio/include"],
++    visibility = ["//visibility:public"],
++)
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 00000000..768e8cc9
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "ll_asio",
++    version = "1.24.0-bcr.0",
++    compatibility_level = 0,
++)
++
++bazel_dep(name = "rules_ll", version = "20230216.0")
+diff --git a/WORKSPACE.bazel b/WORKSPACE.bazel
+new file mode 100644
+index 00000000..1bb8bf6d
+--- /dev/null
++++ b/WORKSPACE.bazel
+@@ -0,0 +1 @@
++# Empty.

--- a/modules/ll_asio/1.24.0-bcr.0/source.json
+++ b/modules/ll_asio/1.24.0-bcr.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-a7gTnrwcl6Q2T25Re5JY7MljRaO/xNEQ+TGsEj29yCQ=",
+    "patch_strip": 1,
+    "patches": {
+        "asio_bzlmod_compatibility_patch.diff": "sha256-h5aZartJUrx6E8yzKxk/yPuNb6GFRS8oq3jT4iAEg8A="
+    },
+    "strip_prefix": "asio-asio-1-24-0",
+    "url": "https://github.com/chriskohlhoff/asio/archive/refs/tags/asio-1-24-0.zip"
+}

--- a/modules/ll_asio/metadata.json
+++ b/modules/ll_asio/metadata.json
@@ -2,7 +2,8 @@
     "homepage": "https://github.com/chriskohlhoff/asio",
     "maintainers": ["aaronmondal", "neqochan"],
     "versions": [
-        "1.24.0"
+        "1.24.0",
+        "1.24.0-bcr.0"
     ],
     "yanked_versions": {}
 }

--- a/modules/ll_json/3.11.2-bcr.0/MODULE.bazel
+++ b/modules/ll_json/3.11.2-bcr.0/MODULE.bazel
@@ -1,0 +1,7 @@
+module(
+    name = "ll_json",
+    version = "3.11.2-bcr.0",
+    compatibility_level = 0,
+)
+
+bazel_dep(name = "rules_ll", version = "20230216.0")

--- a/modules/ll_json/3.11.2-bcr.0/patches/json_bzlmod_compatibility_patch.diff
+++ b/modules/ll_json/3.11.2-bcr.0/patches/json_bzlmod_compatibility_patch.diff
@@ -1,0 +1,34 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 00000000..127409bc
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,8 @@
++load("@rules_ll//ll:defs.bzl", "ll_library")
++
++ll_library(
++    name = "json",
++    exposed_hdrs = ["single_include/nlohmann/json.hpp"],
++    exposed_angled_includes = ["single_include"],
++    visibility = ["//visibility:public"],
++)
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 00000000..d297f6d4
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,7 @@
++module(
++    name = "ll_json",
++    version = "3.11.2-bcr.0",
++    compatibility_level = 0,
++)
++
++bazel_dep(name = "rules_ll", version = "20230216.0")
+diff --git a/WORKSPACE.bazel b/WORKSPACE.bazel
+new file mode 100644
+index 00000000..b7db2541
+--- /dev/null
++++ b/WORKSPACE.bazel
+@@ -0,0 +1 @@
++# Empty.

--- a/modules/ll_json/3.11.2-bcr.0/source.json
+++ b/modules/ll_json/3.11.2-bcr.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-lWUdfR/PLlwxY8PTffbWs+nlAnKZ5r0FDRVzIs7amsk=",
+    "patch_strip": 1,
+    "patches": {
+        "json_bzlmod_compatibility_patch.diff": "sha256-0lJ7+EAcQ0fcVqakn/6bzpdWOzf4dk2Vx1DOO6lDFkM="
+    },
+    "strip_prefix": "json-3.11.2",
+    "url": "https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip"
+}

--- a/modules/ll_json/metadata.json
+++ b/modules/ll_json/metadata.json
@@ -2,7 +2,8 @@
     "homepage": "https://github.com/nlohmann/json",
     "maintainers": ["aaronmondal", "neqochan"],
     "versions": [
-        "3.11.2"
+        "3.11.2",
+        "3.11.2-bcr.0"
     ],
     "yanked_versions": {}
 }

--- a/modules/ll_spdlog/1.11.0-bcr.0/MODULE.bazel
+++ b/modules/ll_spdlog/1.11.0-bcr.0/MODULE.bazel
@@ -1,0 +1,3 @@
+module(name = "ll_spdlog", version = "1.11.0-bcr.0")
+
+bazel_dep(name = "rules_ll", version = "20230216.0")

--- a/modules/ll_spdlog/1.11.0-bcr.0/patches/spdlog_patch.diff
+++ b/modules/ll_spdlog/1.11.0-bcr.0/patches/spdlog_patch.diff
@@ -1,0 +1,56 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+new file mode 100644
+index 00000000..ccf50db2
+--- /dev/null
++++ b/BUILD.bazel
+@@ -0,0 +1,34 @@
++load("@rules_ll//ll:defs.bzl", "ll_library")
++
++
++ll_library(
++    name = "spdlog",
++    srcs = [
++        "src/async.cpp",
++        "src/cfg.cpp",
++        "src/color_sinks.cpp",
++        "src/file_sinks.cpp",
++        "src/spdlog.cpp",
++        "src/stdout_sinks.cpp",
++    ],
++    compile_flags = [
++        "-std=c++20",
++    ],
++    exposed_angled_includes = [
++        "include",
++    ],
++    exposed_defines = [
++        "SPDLOG_USE_STD_FORMAT",
++        "SPDLOG_COMPILED_LIB",
++    ],
++    exposed_hdrs = glob([
++        "include/spdlog/*.h",
++        "include/spdlog/details/*.h",
++        "include/spdlog/sinks/*.h",
++        "include/spdlog/fmt/*.h",
++        "include/spdlog/fmt/bundled/core.h",
++        "include/spdlog/fmt/bundled/format.h",
++        "include/spdlog/cfg/*.h",
++    ]),
++    visibility = ["//visibility:public"],
++)
+diff --git a/MODULE.bazel b/MODULE.bazel
+new file mode 100644
+index 00000000..c3055eb8
+--- /dev/null
++++ b/MODULE.bazel
+@@ -0,0 +1,3 @@
++module(name = "ll_spdlog", version = "1.11.0-bcr.0")
++
++bazel_dep(name = "rules_ll", version = "20230216.0")
+diff --git a/WORKSPACE.bazel b/WORKSPACE.bazel
+new file mode 100644
+index 00000000..5ffb6506
+--- /dev/null
++++ b/WORKSPACE.bazel
+@@ -0,0 +1 @@
++# Empty, but patches may break if there is no line here.

--- a/modules/ll_spdlog/1.11.0-bcr.0/source.json
+++ b/modules/ll_spdlog/1.11.0-bcr.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-M/g8a4bsD7vQ6w9OmA2mdnSU3ArQY5ALz66Lw+nHXyE=",
+    "patch_strip": 1,
+    "patches": {
+        "spdlog_patch.diff": "sha256-igZ5rgBK6J0DsDuOvFaumGjHGt76OoifkirhMIjz+gc="
+    },
+    "strip_prefix": "spdlog-1.11.0",
+    "url": "https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.zip"
+}

--- a/modules/ll_spdlog/metadata.json
+++ b/modules/ll_spdlog/metadata.json
@@ -2,7 +2,8 @@
     "homepage": "https://github.com/gabime/spdlog",
     "maintainers": [],
     "versions": [
-       "1.11.0"
+       "1.11.0",
+       "1.11.0-bcr.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
These are compatible with the new `rules_ll-20230216.0` API.